### PR TITLE
enable self-hosted for libp2p/js-libp2p

### DIFF
--- a/runners.tf
+++ b/runners.tf
@@ -286,6 +286,7 @@ module "runners" {
     "ipfs/kubo",
     "ipni/storetheindex",
     "libp2p/go-libp2p",
+    "libp2p/js-libp2p",
     "libp2p/rust-libp2p",
     "libp2p/test-plans",
     "pl-strflt/tf-aws-gh-runner",


### PR DESCRIPTION
Do not forget to allow access to libp2p/js-libp2p from the self-hosted runners GitHub App. This can be done via libp2p org settings (✅).