### PR TITLE
enable self-hosted runners on protocol/badbits.dwebops.pub

### DIFF
--- a/runners.tf
+++ b/runners.tf
@@ -370,7 +370,8 @@ module "runners" {
     "libp2p/rust-libp2p",
     "libp2p/test-plans",
     "pl-strflt/tf-aws-gh-runner",
-    "quic-go/quic-go"
+    "quic-go/quic-go",
+    "protocol/badbits.dwebops.pub"
   ])
 
   logging_retention_in_days = 30


### PR DESCRIPTION
[protocol/badbits.dwebops.pub`](https://github.com/protocol/badbits.dwebops.pub) is a 30Gb repository and the managed runners run out of disk space when cloning it.

Moving to our internal infrastructure will hopefully resolve these stability issues.